### PR TITLE
Return the raw request body in the API.

### DIFF
--- a/requestbin/models.py
+++ b/requestbin/models.py
@@ -102,6 +102,7 @@ class Request(object):
             method=self.method,
             headers=self.headers,
             query_string=self.query_string,
+            raw=self.raw,
             form_data=self.form_data,
             body=self.body,
             path=self.path,


### PR DESCRIPTION
Hi,

I was using this to generate some test data for our GitHub webhook handling, and when I went to automate it I realized the full raw request body wasn't available in the `/requests` API.

I assume it was an oversight, not a deliberate design decision, since the raw request is available in the UI.

Thanks!
