### PR TITLE
MAX_RAW_SIZE config can be set through env var

### DIFF
--- a/requestbin/config.py
+++ b/requestbin/config.py
@@ -10,7 +10,8 @@ FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", "N1BKhJLnBqLpexO
 
 BIN_TTL = 48*3600
 STORAGE_BACKEND = "requestbin.storage.memory.MemoryStorage"
-MAX_RAW_SIZE = 1024*10
+MAX_RAW_SIZE = int(os.environ.get('MAX_RAW_SIZE', 1024*10))
+print " (config) MAX_RAW_SIZE: %d" % MAX_RAW_SIZE
 IGNORE_HEADERS = []
 MAX_REQUESTS = 20
 CLEANUP_INTERVAL = 3600

--- a/requestbin/config.py
+++ b/requestbin/config.py
@@ -11,7 +11,6 @@ FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", "N1BKhJLnBqLpexO
 BIN_TTL = 48*3600
 STORAGE_BACKEND = "requestbin.storage.memory.MemoryStorage"
 MAX_RAW_SIZE = int(os.environ.get('MAX_RAW_SIZE', 1024*10))
-print " (config) MAX_RAW_SIZE: %d" % MAX_RAW_SIZE
 IGNORE_HEADERS = []
 MAX_REQUESTS = 20
 CLEANUP_INTERVAL = 3600


### PR DESCRIPTION
Useful option when you run RequestBin on your own (Heroku) server, and you need to debug large requests. Related issue: https://github.com/Runscope/requestbin/issues/16

With this modification the `MAX_RAW_SIZE` config can be set through an environment variable (`MAX_RAW_SIZE`).
