### PR TITLE
add heroku button, app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ MIT
 Looking to self-host?
 =====================
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 ## Deploy your own instance using Heroku
 Create a Heroku account if you haven't, then grab the RequestBin source using git:
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "requestbin",
+  "description": "Inspect HTTP requests. Debug webhooks.",
+  "website": "http://requestb.in/",
+  "repository": "https://github.com/Runscope/requestbin",
+  "logo": "http://requestb.in/static/img/logo-2x.png",
+  "keywords": ["python"],
+  "env": {
+    "REALM": {
+      "description": "The number of processes to run.",
+      "value": "prod"
+    }
+  },
+  "addons": [
+    "heroku-redis"
+  ]
+}


### PR DESCRIPTION
An `app.json` file can be used to define how to set up the app on heroku. With this in place, we can put a button next to the heroku set up instructions that will enable a two-click deployment of a self-hosted requestbin.
