### PR TITLE
Use incoming protocol in bin link

### DIFF
--- a/requestbin/templates/bin.html
+++ b/requestbin/templates/bin.html
@@ -6,7 +6,7 @@
 
 {% block binurl %}
   <a href="/{{bin.name}}?inspect"><i class="icon-circle icon-2x" style="color: rgb{{bin.color}}"></i></a>
-  <input type="text" value="http://{{host}}/{{bin.name}}" onclick="this.select()" /> 
+  <input type="text" value="{{base_url}}/{{bin.name}}" onclick="this.select()" />
   {% if bin.private %}<i class="icon-lock"></i>{% endif %}
 {% endblock %}
 
@@ -19,7 +19,7 @@
         <div class="message-list">
           <div class="row-fluid">
             <div class="span4">
-              http://{{host}}<br>
+              {{base_url}}<br>
               <span class="method">{{request.method}}</span> 
               <span class="absolute-path">{{request.path}}</span><span class="querystring">{{request.query_string|to_qs}}</span>
             </div>
@@ -44,7 +44,7 @@
 
       <h4 class="text-center">Bin URL</h4>
       <h2 class="text-center">
-        <input class="xxlarge input-xxlarge" type="text" value="http://{{host}}/{{bin.name}}" onclick="this.select()" style="border-color: rgb{{bin.color}}; border-width: 3px;" /></h2>
+        <input class="xxlarge input-xxlarge" type="text" value="{{base_url}}/{{bin.name}}" onclick="this.select()" style="border-color: rgb{{bin.color}}; border-width: 3px;" /></h2>
       <p class="text-center">{% if bin.private %}This is a private bin. Requests are only viewable from this computer.{% endif %}
 
       <hr>
@@ -54,17 +54,17 @@
       <h4>Make a request to get started.</h4>
 
       <h5>cURL</h5>
-      <pre>curl -X POST -d "fizz=buzz" http://{{host}}/{{bin.name}}</pre>
+      <pre>curl -X POST -d "fizz=buzz" {{base_url}}/{{bin.name}}</pre>
 
       <h5>Python (with Requests)</h5>
       <pre class="prettyprint">import requests, time
-r = requests.post('http://{{host}}/{{bin.name}}', data={"ts":time.time()})
+r = requests.post('{{base_url}}/{{bin.name}}', data={"ts":time.time()})
 print r.status_code
 print r.content</pre>
 
       <h5>Node.js (with request)</h5>
       <pre class="prettyprint">var request = require('request');
-var url ='http://{{host}}/{{bin.name}}'
+var url ='{{base_url}}/{{bin.name}}'
 request(url, function (error, response, body) {
   if (!error) {
     console.log(body);
@@ -73,7 +73,7 @@ request(url, function (error, response, body) {
 
       <h5>Ruby</h5>
       <pre class="prettyprint">require 'open-uri'
-result = open('http://{{host}}/{{bin.name}}')
+result = open('{{base_url}}/{{bin.name}}')
 result.lines { |f| f.each_line {|line| p line} }</pre>
 
       <h5>C# / .NET</h5>
@@ -93,7 +93,7 @@ namespace RequestBinExample
     private static async Task MakeRequest()
     {
       var httpClient = new HttpClient();
-      var response = await httpClient.GetAsync(new Uri("http://{{host}}/{{bin.name}}"));
+      var response = await httpClient.GetAsync(new Uri("{{base_url}}/{{bin.name}}"));
       var body = await response.Content.ReadAsStringAsync();
       Console.WriteLine(body);
     }
@@ -110,7 +110,7 @@ import java.io.*;
 public class RequestBinTutorial {
   public static void main(String[] args) {
     HttpClient client = new HttpClient();
-    GetMethod method = new GetMethod("http://{{host}}/{{bin.name}}");
+    GetMethod method = new GetMethod("{{base_url}}/{{bin.name}}");
     try {
       int statusCode = client.executeMethod(method);
       byte[] responseBody = method.getResponseBody();
@@ -126,7 +126,7 @@ public class RequestBinTutorial {
 
       <h5>PHP</h5>
       <pre class="prettyprint">&lt;?php
-    $result = file_get_contents('http://{{host}}/{{bin.name}}');
+    $result = file_get_contents('{{base_url}}/{{bin.name}}');
     echo $result;
 ?&gt;</pre>
 

--- a/requestbin/views.py
+++ b/requestbin/views.py
@@ -43,7 +43,7 @@ def bin(name):
         update_recent_bins(name)
         return render_template('bin.html',
             bin=bin,
-            host=request.host)
+            base_url=request.scheme+'://'+request.host)
     else:
         db.create_request(bin, request)
         resp = make_response("ok\n")


### PR DESCRIPTION
Better supports HTTPS by default by using whatever protocol is in use on the incoming request. So if you visit http://mybin.test/abcd?inspect, you see `http://mybin.test/abcd` in the copyable fields and code examples. But if you visit https://mybin.test/abcd?inspect you see `https://mybin.test/abcd` instead.
