### PR TITLE
Allow optional file extensions on requests

### DIFF
--- a/requestbin/__init__.py
+++ b/requestbin/__init__.py
@@ -63,7 +63,9 @@ app.jinja_env.filters['exact_time'] = exact_time
 app.jinja_env.filters['short_date'] = short_date
 
 app.add_url_rule('/', 'views.home')
-app.add_url_rule('/<name>', 'views.bin', methods=['GET', 'POST', 'DELETE', 'PUT', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE'])
+all_methods = ['GET', 'POST', 'DELETE', 'PUT', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE']
+app.add_url_rule('/<name>', 'views.bin', methods=all_methods, defaults={'filetype': ''})
+app.add_url_rule('/<name>.<filetype>', 'views.bin', methods=all_methods)
 
 app.add_url_rule('/docs/<name>', 'views.docs')
 app.add_url_rule('/api/v1/bins', 'api.bins', methods=['POST'])

--- a/requestbin/views.py
+++ b/requestbin/views.py
@@ -32,7 +32,7 @@ def home():
 
 
 @app.endpoint('views.bin')
-def bin(name):
+def bin(name, filetype):
     try:
         bin = db.lookup_bin(name)
     except KeyError:


### PR DESCRIPTION
Some services insist on using file extensions, such as `.json`, to indicate the filetype of the request. I don't like this requirement, personally, but it is what it is. This branch allows any extension to optionally be included in requests to the bin.
