### PR TITLE
reverted py2-pip to py-pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2.7-alpine
 
 RUN apk update && apk upgrade && \
     apk add \
-        gcc python python-dev py2-pip \
+        gcc python python-dev py-pip \
         # greenlet
         musl-dev \
         # sys/queue.h


### PR DESCRIPTION
As seen [here](https://github.com/docker-library/python/tree/master/2.7/alpine), python:2.7-alpine reverted back to Alpine 3.4 for now. py2-pip does not work in 3.4, so I changed it back to py-pip. Now the docker container should actually build instead of giving the following error:

"ERROR: unsatisfiable constraints:
  py2-pip (missing):
    required by: world[py2-pip]
ERROR: Service 'app' failed to build: The command '/bin/sh -c apk update && apk upgrade &&     apk add         gcc python python-dev py2-pip         musl-dev         bsd-compat-headers         libevent-dev     && rm -rf /var/cache/apk/*' returned a non-zero code: 1"

TODO: This will need to be changed back to py2-pip whenever the python:2.7-alpine team is able to successfully switch over to Alpine 3.5