### PR TITLE
Add Habitat Packaging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+export HAB_DOCKER_OPTS="-p 8080:8080"
+
+# Avoid starting the supervisor automatically
+# We will be injecting the config via the .studiorc
+export HAB_STUDIO_SUP=false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ codekit-config.json
 
 # Mac Files
 **/.DS_Store
+results/
+.bash_history

--- a/.studiorc
+++ b/.studiorc
@@ -43,9 +43,9 @@ function start_redis() {
 
   mkdir -p /hab/user/redis/config/
 
-  echo "port = $REDIS_PORT" > /hab/user/redis/config/user.toml
+  printf "port = $REDIS_PORT\n" > /hab/user/redis/config/user.toml
 
-  hab start core/redis
+  hab start lancewf/redis
 
   wait_or_fail_for_port_to_listen $REDIS_PORT
 }

--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+hab pkg install chef/ci-studio-common >/dev/null
+source "$(hab pkg path chef/ci-studio-common)/bin/studio-common"
+
+install_if_missing core/curl curl
+
+export REDIS_PORT=6379;
+export REQUESTBIN_PORT=8080;
+
+function start() {
+  install_if_missing core/busybox-static netstat;
+  netstat -an | grep $REQUESTBIN_PORT | grep LISTEN >/dev/null 2>/dev/null
+  if [ $? == 0 ]; then
+    echo "requestbin is already running";
+    return;
+  fi
+
+  start_sup
+
+  start_redis
+
+  build
+  
+  mkdir -p /hab/user/requestbin/config/
+
+  printf "[http.listen]\nport = $REQUESTBIN_PORT" > /hab/user/requestbin/config/user.toml
+
+  hab start $HAB_ORIGIN/requestbin
+
+  wait_or_fail_for_port_to_listen $REQUESTBIN_PORT
+}
+
+function start_redis() {
+  install_if_missing core/busybox-static netstat;
+  netstat -an | grep $REDIS_PORT | grep LISTEN >/dev/null 2>/dev/null
+  if [ $? == 0 ]; then
+    echo "redis is already running";
+    return;
+  fi
+
+  start_sup
+
+  mkdir -p /hab/user/redis/config/
+
+  echo "port = $REDIS_PORT" > /hab/user/redis/config/user.toml
+
+  hab start core/redis
+
+  wait_or_fail_for_port_to_listen $REDIS_PORT
+}
+
+
+eval "$(curl -s -L https://gist.githubusercontent.com/lancewf/6b58d3accb36c2ae5681a40bd574b124/raw/345232f9fab0bb2892be15419bc5e644e55f0d9c/hab_studio_addition)"

--- a/.studiorc
+++ b/.studiorc
@@ -26,7 +26,7 @@ function start() {
 
   printf "[http.listen]\nport = $REQUESTBIN_PORT" > /hab/user/requestbin/config/user.toml
 
-  hab start $HAB_ORIGIN/requestbin
+  hab start $HAB_ORIGIN/requestbin --bind redis:redis.default
 
   wait_or_fail_for_port_to_listen $REQUESTBIN_PORT
 }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ $ sudo docker-compose up -d
 
 Your own private RequestBin will be running on this server.
 
+## Deploy your own instance using Habitat.sh
+
+On the server/machine you want to host this, you'll first need a machine with
+Habitat.sh installed, then run the below commands:
+
+```
+hab svc load lancewf/redis
+hab svc load lancewf/requestbin --bind redis:redis.default
+```
+
+Your own private RequestBin will be running on port 8080.
 
 Contributors
 ------------

--- a/habitat/README.md
+++ b/habitat/README.md
@@ -1,0 +1,9 @@
+# Habitat package: requestbin
+
+## Description
+
+Provide a brief description of the `requestbin` plan / purpose.
+
+## Usage
+
+Describe the general usage for the `requestbin` plan

--- a/habitat/config/config.py
+++ b/habitat/config/config.py
@@ -1,33 +1,28 @@
 import os, urlparse
-DEBUG = True
-REALM = os.environ.get('REALM', 'local')
 
-{{#if cfg.http.listen.local_only ~}}
-ROOT_URL = "http://127.0.0.1:{{cfg.http.listen.port}}"
-{{else ~}}
-ROOT_URL = "http://0.0.0.0:{{cfg.http.listen.port}}"
-{{/if ~}}
+REALM = "{{cfg.realm}}"
+DEBUG = {{cfg.debug}}
 
 PORT_NUMBER = {{cfg.http.listen.port}}
 
-ENABLE_CORS = False
-CORS_ORIGINS = "*"
+ENABLE_CORS = {{cfg.enable_cors}}
+CORS_ORIGINS = "{{cfg.cors_origins}}"
 
-FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", "N1BKhJLnBqLpexOZdklsfDKFJDKFadsfs9a3r324YB7B73AglRmrHMDQ9RhXz35")
+FLASK_SESSION_SECRET_KEY = "{{cfg.flask_session_secret_key}}"
 
-BIN_TTL = 48*3600
+BIN_TTL = {{cfg.bin_ttl}}
 STORAGE_BACKEND = "requestbin.storage.redis.RedisStorage"
-MAX_RAW_SIZE = int(os.environ.get('MAX_RAW_SIZE', 1024*10))
-IGNORE_HEADERS = []
-MAX_REQUESTS = 20
-CLEANUP_INTERVAL = 3600
+MAX_RAW_SIZE = {{cfg.max_raw_size}}
+IGNORE_HEADERS = "{{strJoin cfg.ignore_headers ","}}".split(",")
+MAX_REQUESTS = {{cfg.max_requests}}
+CLEANUP_INTERVAL = {{cfg.cleanup_interval}}
 
-REDIS_URL = "http://127.0.0.1:6379"
+REDIS_URL = "http://127.0.0.1:{{bind.redis.first.cfg.port}}"
 REDIS_HOST = "127.0.0.1"
-REDIS_PORT = 6379
+REDIS_PORT = {{bind.redis.first.cfg.port}}
 REDIS_PASSWORD = None
-REDIS_DB = 9
+REDIS_DB = {{cfg.redis.db}}
 
-REDIS_PREFIX = "requestbin"
+REDIS_PREFIX = "{{cfg.redis.prefix}}"
 
-BUGSNAG_KEY = ""
+BUGSNAG_KEY = "{{cfg.bugsnag_key}}"

--- a/habitat/config/config.py
+++ b/habitat/config/config.py
@@ -16,14 +16,14 @@ CORS_ORIGINS = "*"
 FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", "N1BKhJLnBqLpexOZdklsfDKFJDKFadsfs9a3r324YB7B73AglRmrHMDQ9RhXz35")
 
 BIN_TTL = 48*3600
-STORAGE_BACKEND = "requestbin.storage.memory.MemoryStorage"
+STORAGE_BACKEND = "requestbin.storage.redis.RedisStorage"
 MAX_RAW_SIZE = int(os.environ.get('MAX_RAW_SIZE', 1024*10))
 IGNORE_HEADERS = []
 MAX_REQUESTS = 20
 CLEANUP_INTERVAL = 3600
 
-REDIS_URL = "http://localhost:6379"
-REDIS_HOST = "localhost"
+REDIS_URL = "http://127.0.0.1:6379"
+REDIS_HOST = "127.0.0.1"
 REDIS_PORT = 6379
 REDIS_PASSWORD = None
 REDIS_DB = 9
@@ -31,33 +31,3 @@ REDIS_DB = 9
 REDIS_PREFIX = "requestbin"
 
 BUGSNAG_KEY = ""
-
-if REALM == 'prod':
-    DEBUG = False
-    ROOT_URL = "http://requestb.in"
-
-    FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", FLASK_SESSION_SECRET_KEY)
-
-    STORAGE_BACKEND = "requestbin.storage.redis.RedisStorage"
-
-    REDIS_URL = os.environ.get("REDIS_URL")
-    url_parts = urlparse.urlparse(REDIS_URL)
-    REDIS_HOST = url_parts.hostname
-    REDIS_PORT = url_parts.port
-    REDIS_PASSWORD = url_parts.password
-    REDIS_DB = url_parts.fragment
-
-    BUGSNAG_KEY = os.environ.get("BUGSNAG_KEY", BUGSNAG_KEY)
-
-    IGNORE_HEADERS = """
-X-Varnish
-X-Forwarded-For
-X-Heroku-Dynos-In-Use
-X-Request-Start
-X-Heroku-Queue-Wait-Time
-X-Heroku-Queue-Depth
-X-Real-Ip
-X-Forwarded-Proto
-X-Via
-X-Forwarded-Port
-""".split("\n")[1:-1]

--- a/habitat/config/config.py
+++ b/habitat/config/config.py
@@ -1,0 +1,63 @@
+import os, urlparse
+DEBUG = True
+REALM = os.environ.get('REALM', 'local')
+
+{{#if cfg.http.listen.local_only ~}}
+ROOT_URL = "http://127.0.0.1:{{cfg.http.listen.port}}"
+{{else ~}}
+ROOT_URL = "http://0.0.0.0:{{cfg.http.listen.port}}"
+{{/if ~}}
+
+PORT_NUMBER = {{cfg.http.listen.port}}
+
+ENABLE_CORS = False
+CORS_ORIGINS = "*"
+
+FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", "N1BKhJLnBqLpexOZdklsfDKFJDKFadsfs9a3r324YB7B73AglRmrHMDQ9RhXz35")
+
+BIN_TTL = 48*3600
+STORAGE_BACKEND = "requestbin.storage.memory.MemoryStorage"
+MAX_RAW_SIZE = int(os.environ.get('MAX_RAW_SIZE', 1024*10))
+IGNORE_HEADERS = []
+MAX_REQUESTS = 20
+CLEANUP_INTERVAL = 3600
+
+REDIS_URL = "http://localhost:6379"
+REDIS_HOST = "localhost"
+REDIS_PORT = 6379
+REDIS_PASSWORD = None
+REDIS_DB = 9
+
+REDIS_PREFIX = "requestbin"
+
+BUGSNAG_KEY = ""
+
+if REALM == 'prod':
+    DEBUG = False
+    ROOT_URL = "http://requestb.in"
+
+    FLASK_SESSION_SECRET_KEY = os.environ.get("SESSION_SECRET_KEY", FLASK_SESSION_SECRET_KEY)
+
+    STORAGE_BACKEND = "requestbin.storage.redis.RedisStorage"
+
+    REDIS_URL = os.environ.get("REDIS_URL")
+    url_parts = urlparse.urlparse(REDIS_URL)
+    REDIS_HOST = url_parts.hostname
+    REDIS_PORT = url_parts.port
+    REDIS_PASSWORD = url_parts.password
+    REDIS_DB = url_parts.fragment
+
+    BUGSNAG_KEY = os.environ.get("BUGSNAG_KEY", BUGSNAG_KEY)
+
+    IGNORE_HEADERS = """
+X-Varnish
+X-Forwarded-For
+X-Heroku-Dynos-In-Use
+X-Request-Start
+X-Heroku-Queue-Wait-Time
+X-Heroku-Queue-Depth
+X-Real-Ip
+X-Forwarded-Proto
+X-Via
+X-Forwarded-Port
+""".split("\n")[1:-1]

--- a/habitat/config/config.py
+++ b/habitat/config/config.py
@@ -17,10 +17,19 @@ IGNORE_HEADERS = "{{strJoin cfg.ignore_headers ","}}".split(",")
 MAX_REQUESTS = {{cfg.max_requests}}
 CLEANUP_INTERVAL = {{cfg.cleanup_interval}}
 
+{{#if bind.redis.first.cfg.local_only ~}}
 REDIS_URL = "http://127.0.0.1:{{bind.redis.first.cfg.port}}"
 REDIS_HOST = "127.0.0.1"
+{{else ~}}
+REDIS_URL = "http://{{bind.redis.first.sys.ip}}:{{bind.redis.first.cfg.port}}"
+REDIS_HOST = "{{bind.redis.first.sys.ip}}"
+{{/if ~}}
 REDIS_PORT = {{bind.redis.first.cfg.port}}
+{{#if cfg.redis.password ~}}
+REDIS_PASSWORD = cfg.redis.password
+{{else ~}}
 REDIS_PASSWORD = None
+{{/if ~}}
 REDIS_DB = {{cfg.redis.db}}
 
 REDIS_PREFIX = "{{cfg.redis.prefix}}"

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,6 +1,21 @@
-# Use this file to templatize your application's native configuration files.
-# See the docs at https://www.habitat.sh/docs/create-packages-configure/.
-# You can safely delete this file if you don't need it.
+flask_session_secret_key = "N1BKhJLnBqLpexOZdklsfDKFJDKFadsfs9a3r324YB7B73AglRmrHMDQ9RhXz35"
+max_requests = 20
+cleanup_interval = 3600
+max_raw_size = 10240
+bin_ttl = 172800
+enable_cors = "False"
+cors_origins = "*"
+debug = "False"
+ignore_headers = ['X-Varnish','X-Forwarded-For','X-Heroku-Dynos-In-Use','X-Request-Start','X-Heroku-Queue-Wait-Time','X-Heroku-Queue-Depth','X-Real-Ip','X-Forwarded-Proto','X-Via','X-Forwarded-Port']
+bugsnag_key = ""
+# 'local' or 'prod'
+realm = "local"
+
+[redis]
+db = 9
+prefix = "requestbin"
+
 [http.listen]
 port = 8080
 local_only = false
+

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,6 @@
+# Use this file to templatize your application's native configuration files.
+# See the docs at https://www.habitat.sh/docs/create-packages-configure/.
+# You can safely delete this file if you don't need it.
+[http.listen]
+port = 8080
+local_only = false

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -14,6 +14,7 @@ realm = "local"
 [redis]
 db = 9
 prefix = "requestbin"
+password = ""
 
 [http.listen]
 port = 8080

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,5 +1,23 @@
 #!/bin/bash
 exec 2>&1
 
+############# Connect to redis #############################
+redis_ready() {
+    echo "redis-cli -p {{bind.redis.first.cfg.port}} ping"
+    local expected="PONG"
+    local actual=$(redis-cli -p {{bind.redis.first.cfg.port}} ping)
+    if [ "$actual" == "$expected" ]
+    then
+        return 0
+    else
+        return 1
+    fi
+}
+
+if !(redis_ready) then
+     echo "waiting for redis ..."
+     exit 1
+fi
+
 cp -R {{pkg.path}}/app {{pkg.svc_data_path}}
 cp {{pkg.svc_config_path}}/config.py {{pkg.svc_data_path}}/app/requestbin/.

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/bash
+exec 2>&1
+
+cp -R {{pkg.path}}/app {{pkg.svc_data_path}}
+cp {{pkg.svc_config_path}}/config.py {{pkg.svc_data_path}}/app/requestbin/.

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,9 +1,11 @@
 #!/bin/bash
 exec 2>&1
 
+cd {{pkg.svc_data_path}}/app/
+source venv/bin/activate
 {{#if cfg.http.listen.local_only ~}}
-{{pkg.svc_data_path}}/app/venv/bin/gunicorn --bind 127.0.0.1:{{cfg.http.listen.port}} --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
+venv/bin/gunicorn --bind 127.0.0.1:{{cfg.http.listen.port}} --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
 {{else ~}}
-{{pkg.svc_data_path}}/app/venv/bin/gunicorn --bind 0.0.0.0:{{cfg.http.listen.port}} --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
+venv/bin/gunicorn --bind 0.0.0.0:{{cfg.http.listen.port}} --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
 {{/if ~}}
 

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,0 +1,9 @@
+#!/bin/bash
+exec 2>&1
+
+{{#if cfg.http.listen.local_only ~}}
+{{pkg.svc_data_path}}/app/venv/bin/gunicorn --bind 127.0.0.1:{{cfg.http.listen.port}} --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
+{{else ~}}
+{{pkg.svc_data_path}}/app/venv/bin/gunicorn --bind 0.0.0.0:{{cfg.http.listen.port}} --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
+{{/if ~}}
+

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,39 @@
+pkg_name=requestbin
+pkg_origin=lancewf
+pkg_version="0.1.0"
+pkg_maintainer="Lance Finfrock <lfinfrock@chef.io>"
+pkg_license=('Apache-2.0')
+pkg_source=""
+pkg_deps=(core/coreutils core/python2)
+pkg_build_deps=(core/virtualenv core/gcc)
+
+pkg_svc_user=root
+pkg_svc_group=$pkg_svc_user
+
+pkg_exports=(
+   [port]=http.listen.port
+   [local_only]=http.listen.local_only
+)
+
+pkg_binds=(
+
+)
+
+do_unpack() {
+    mkdir -p $pkg_prefix/app
+    build_line "Copying project data to $pkg_prefix/app"
+    cp -r ${PLAN_CONTEXT}/../requestbin $pkg_prefix/app/
+    cp ${PLAN_CONTEXT}/../*.py $pkg_prefix/app/
+    cp ${PLAN_CONTEXT}/../requirements.txt $pkg_prefix/app/
+}
+
+do_build(){
+  return 0
+}
+
+do_install() {
+    cd $pkg_prefix/app/
+    virtualenv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+}

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_exports=(
 )
 
 pkg_binds=(
-  [redis]="port"
+  [redis]="port local_only"
 )
 
 do_unpack() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -4,7 +4,7 @@ pkg_version="0.1.0"
 pkg_maintainer="Lance Finfrock <lfinfrock@chef.io>"
 pkg_license=('Apache-2.0')
 pkg_source=""
-pkg_deps=(core/coreutils core/python2)
+pkg_deps=(core/coreutils core/python2 core/redis)
 pkg_build_deps=(core/virtualenv core/gcc)
 
 pkg_svc_user=root
@@ -16,7 +16,7 @@ pkg_exports=(
 )
 
 pkg_binds=(
-
+  [redis]="port"
 )
 
 do_unpack() {


### PR DESCRIPTION
Added habitat packaging to allow another option of building and deploying this service. With this new packaging the service has been added to the habitat builder at lancewf/requestbin. 

To test this packaging in the habitat studio run `hab studio enter` from the root directory. Then from inside the studio run `start`. This will start redis and then the requestbin at port 8080. 